### PR TITLE
Octree rewrite

### DIFF
--- a/MarsMiner.Client/Graphics/OctreeTestRenderer.cs
+++ b/MarsMiner.Client/Graphics/OctreeTestRenderer.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Threading;
+using System.Collections.Generic;
 
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 
 using MarsMiner.Shared;
-using System.Threading;
 
 namespace MarsMiner.Client.Graphics
 {
@@ -30,6 +31,8 @@ namespace MarsMiner.Client.Graphics
         public float[] FindVertices()
         {
             List<float> verts = new List<float>();
+            FindSolidFacesDelegate<OctreeTestBlockType> solidCheck =
+                ( x => ( x == OctreeTestBlockType.Empty ? Face.None : Face.All ) );
 
             foreach ( OctreeTest chunkOctree in Chunk.Octrees )
             {
@@ -45,9 +48,7 @@ namespace MarsMiner.Client.Graphics
                     float r0 = y0 / 256.0f;
                     float r1 = y1 / 256.0f;
 
-                    octree.UpdateFace( Face.All );
-
-                    if ( ( octree.Exposed & Face.Front ) != 0 )
+                    if ( octree.IsFaceExposed( Face.Front, solidCheck ) )
                         verts.AddRange( new float[]
                         {
                             x0, y0, z0, r0,
@@ -56,7 +57,7 @@ namespace MarsMiner.Client.Graphics
                             x0, y1, z0, r1,
                         } );
 
-                    if ( ( octree.Exposed & Face.Right ) != 0 )
+                    if ( octree.IsFaceExposed( Face.Right, solidCheck ) )
                         verts.AddRange( new float[]
                         {
                             x1, y0, z0, r0,
@@ -65,7 +66,7 @@ namespace MarsMiner.Client.Graphics
                             x1, y1, z0, r1,
                         } );
 
-                    if ( ( octree.Exposed & Face.Back ) != 0 )
+                    if ( octree.IsFaceExposed( Face.Back, solidCheck ) )
                         verts.AddRange( new float[]
                         {
                             x1, y0, z1, r0,
@@ -74,7 +75,7 @@ namespace MarsMiner.Client.Graphics
                             x1, y1, z1, r1,
                         } );
 
-                    if ( ( octree.Exposed & Face.Left ) != 0 )
+                    if ( octree.IsFaceExposed( Face.Left, solidCheck ) )
                         verts.AddRange( new float[]
                         {
                             x0, y0, z1, r0,
@@ -83,7 +84,7 @@ namespace MarsMiner.Client.Graphics
                             x0, y1, z1, r1,
                         } );
 
-                    if ( ( octree.Exposed & Face.Bottom ) != 0 )
+                    if ( octree.IsFaceExposed( Face.Bottom, solidCheck ) )
                         verts.AddRange( new float[]
                         {
                             x0, y0, z0, r0,
@@ -92,7 +93,7 @@ namespace MarsMiner.Client.Graphics
                             x1, y0, z0, r0,
                         } );
 
-                    if ( ( octree.Exposed & Face.Top ) != 0 )
+                    if ( octree.IsFaceExposed( Face.Top, solidCheck ) )
                         verts.AddRange( new float[]
                         {
                             x0, y1, z0, r1,

--- a/MarsMiner.Client/Graphics/OctreeTestRenderer.cs
+++ b/MarsMiner.Client/Graphics/OctreeTestRenderer.cs
@@ -33,17 +33,17 @@ namespace MarsMiner.Client.Graphics
 
             foreach ( OctreeTest chunkOctree in Chunk.Octrees )
             {
-                foreach ( OctreeTest octree in chunkOctree )
+                foreach ( OctreeNode<OctreeTestBlockType> octree in chunkOctree )
                 {
                     if ( octree.Value == OctreeTestBlockType.Empty )
                         continue;
 
-                    float x0 = octree.X; float x1 = octree.X + octree.Size;
-                    float y0 = octree.Y; float y1 = octree.Y + octree.Size;
-                    float z0 = octree.Z; float z1 = octree.Z + octree.Size;
+                    float x0 = octree.X; float x1 = x0 + octree.Size;
+                    float y0 = octree.Y; float y1 = y0 + octree.Size;
+                    float z0 = octree.Z; float z1 = z0 + octree.Size;
 
-                    float r0 = octree.Bottom / 256.0f;
-                    float r1 = octree.Top / 256.0f;
+                    float r0 = y0 / 256.0f;
+                    float r1 = y1 / 256.0f;
 
                     octree.UpdateFace( Face.All );
 

--- a/MarsMiner.Shared/Cuboid.cs
+++ b/MarsMiner.Shared/Cuboid.cs
@@ -52,6 +52,15 @@ namespace MarsMiner.Shared
             get { return Width * Height * Depth; }
         }
 
+        public Cuboid( int x, int y, int z, int size )
+        {
+            X = x;
+            Y = y;
+            Z = z;
+
+            Width = Height = Depth = size;
+        }
+
         public Cuboid( int x, int y, int z, int width, int height, int depth )
         {
             X = x;
@@ -70,6 +79,18 @@ namespace MarsMiner.Shared
                 && cuboid.Front <= Back && cuboid.Back >= Front;
         }
 
+        public bool IsIntersecting( int x, int y, int z, int size )
+        {
+            return x <= Right && x + size >= Left
+                && y <= Top && y + size >= Bottom
+                && z <= Back && z + size >= Front;
+        }
+
+        public bool IsIntersecting( int x, int y, int z, int width, int height, int depth )
+        {
+            return IsIntersecting( new Cuboid( x, y, z, width, height, depth ) );
+        }
+
         public Cuboid FindIntersection( Cuboid cuboid )
         {
             if ( !IsIntersecting( cuboid ) )
@@ -84,6 +105,27 @@ namespace MarsMiner.Shared
             int back = Math.Min( Back, cuboid.Back );
 
             return new Cuboid( left, bottom, front, right - left, top - bottom, back - front );
+        }
+
+        public Cuboid FindIntersection( int x, int y, int z, int size )
+        {
+            if ( !IsIntersecting( x, y, z, size ) )
+                throw new InvalidOperationException();
+
+            int left = Math.Max( Left, x );
+            int bottom = Math.Max( Bottom, y );
+            int front = Math.Max( Front, z );
+
+            int right = Math.Min( Right, x + size );
+            int top = Math.Min( Top, y + size );
+            int back = Math.Min( Back, z + size );
+
+            return new Cuboid( left, bottom, front, right - left, top - bottom, back - front );
+        }
+
+        public Cuboid FindIntersection( int x, int y, int z, int width, int height, int depth )
+        {
+            return FindIntersection( new Cuboid( x, y, z, width, height, depth ) );
         }
 
         public override bool Equals( object obj )

--- a/MarsMiner.Shared/Octant.cs
+++ b/MarsMiner.Shared/Octant.cs
@@ -52,9 +52,18 @@ namespace MarsMiner.Shared
             return XYZ[ right ? 1 : 0, top ? 1 : 0, back ? 1 : 0 ];
         }
 
-        public readonly int X;
-        public readonly int Y;
-        public readonly int Z;
+        public int X
+        {
+            get { return Index >> 2; }
+        }
+        public int Y
+        {
+            get { return ( Index >> 1 ) % 2; }
+        }
+        public int Z
+        {
+            get { return Index % 2; }
+        }
 
         public readonly int Index;
 
@@ -70,10 +79,6 @@ namespace MarsMiner.Shared
 
         private Octant( int x, int y, int z )
         {
-            X = x;
-            Y = y;
-            Z = z;
-
             Index = x << 2 | y << 1 | z;
         }
 

--- a/MarsMiner.Shared/Octree.cs
+++ b/MarsMiner.Shared/Octree.cs
@@ -169,6 +169,7 @@ namespace MarsMiner.Shared
         {
             Parent = parent;
             myValue = parent.myValue;
+            Solidity = parent.Solidity;
         }
 
         public OctreeNode<T> this[ Octant octant ]
@@ -394,23 +395,25 @@ namespace MarsMiner.Shared
         {
             Cuboid dims = Parent.FindDimensionsOfChild( this );
 
+            int size = dims.Width;
+
             switch ( face )
             {
                 case Face.Left:
-                    dims.X -= dims.Width; break;
+                    dims.X -= size; break;
                 case Face.Right:
-                    dims.X += dims.Width; break;
+                    dims.X += size; break;
                 case Face.Bottom:
-                    dims.Y -= dims.Width; break;
+                    dims.Y -= size; break;
                 case Face.Top:
-                    dims.Y += dims.Width; break;
+                    dims.Y += size; break;
                 case Face.Front:
-                    dims.Z -= dims.Width; break;
+                    dims.Z -= size; break;
                 case Face.Back:
-                    dims.Z += dims.Width; break;
+                    dims.Z += size; break;
             }
 
-            return Parent.FindNode( dims.X, dims.Y, dims.Z, dims.Width );
+            return Parent.FindNode( dims.X, dims.Y, dims.Z, size );
         }
 
         public IEnumerator<OctreeNode<T>> GetEnumerator()

--- a/MarsMiner.Shared/Octree.cs
+++ b/MarsMiner.Shared/Octree.cs
@@ -16,42 +16,107 @@ namespace MarsMiner.Shared
         Bottom  = 32
     }
 
-    public class Octree<T> : IEnumerable<Octree<T>>
+    public class Octree<T> : OctreeNode<T>
+    {
+        private readonly int myX;
+        private readonly int myY;
+        private readonly int myZ;
+
+        private readonly int mySize;
+
+        public override int X
+        {
+	        get { return myX; }
+        }
+        public override int Y
+        {
+	        get { return myY; }
+        }
+        public override int Z
+        {
+	        get { return myZ; }
+        }
+        
+        public override int Size
+        {
+	        get { return mySize; }
+        }
+
+        public Octree( int x, int y, int z, int size )
+        {
+            myX = x;
+            myY = y;
+            myZ = z;
+
+            mySize = size;
+        }
+
+        public void SetCuboid( Cuboid cuboid, T value )
+        {
+            SetCuboid( X, Y, Z, Size, cuboid, value );
+        }
+
+        public void SetCuboid( int x, int y, int z, int width, int height, int depth, T value )
+        {
+            SetCuboid( X, Y, Z, Size, new Cuboid( x, y, z, width, height, depth ), value );
+        }
+
+        public override OctreeNode<T> FindNode( int x, int y, int z, int size )
+        {
+            if ( x < X || y < Y || z < Z || x >= X + Size || y >= Y + Size || z >= Z + Size )
+                return FindExternalNode( x, y, z, size );
+
+            return FindNode( X, Y, Z, Size, x, y, z, size );
+        }
+
+        protected virtual OctreeNode<T> FindExternalNode( int x, int y, int z, int size )
+        {
+            return null;
+        }
+
+        protected override Cuboid FindDimensionsOfChild( OctreeNode<T> child )
+        {
+            Octant oct = FindOctantOfChild( child );
+
+            int size = Size >> 1;
+
+            return new Cuboid( X + oct.X * size, Y + oct.Y * size, Z + oct.Z * size, size );
+        }
+
+        protected override OctreeNode<T> FindNeighbour( Face face )
+        {
+            return null;
+        }
+    }
+
+    public class OctreeNode<T> : IEnumerable<OctreeNode<T>>
     {
         private T myValue;
-        private Octree<T>[] myChildren;
+        private OctreeNode<T>[] myChildren;
         private Face myChangedFaces;
         private Face myExposed;
 
-        public readonly int X;
-        public readonly int Y;
-        public readonly int Z;
+        public Octant Octant
+        {
+            get { return Parent.FindOctantOfChild( this ); }
+        }
 
-        public readonly int Size;
+        public virtual int X
+        {
+            get { return Parent.X + Octant.X * Size; }
+        }
+        public virtual int Y
+        {
+            get { return Parent.Y + Octant.Y * Size; }
+        }
+        public virtual int Z
+        {
+            get { return Parent.Z + Octant.Z * Size; }
+        }
 
-        public int Left
+        public virtual int Size
         {
-            get { return X; }
-        }
-        public int Bottom
-        {
-            get { return Y; }
-        }
-        public int Front
-        {
-            get { return Z; }
-        }
-        public int Right
-        {
-            get { return X + Size; }
-        }
-        public int Top
-        {
-            get { return Y + Size; }
-        }
-        public int Back
-        {
-            get { return Z + Size; }
+            get { return Parent.Size >> 1; }
         }
 
         public Face Solidity { get; private set; }
@@ -66,12 +131,7 @@ namespace MarsMiner.Shared
             }
         }
 
-        public Cuboid Cube
-        {
-            get { return new Cuboid( X, Y, Z, Size, Size, Size ); }
-        }
-
-        public readonly Octree<T> Parent;
+        public readonly OctreeNode<T> Parent;
 
         public T Value
         {
@@ -98,36 +158,20 @@ namespace MarsMiner.Shared
             get { return myChildren != null; }
         }
 
-        public Octree( int size )
+        public OctreeNode()
         {
-            Size = size;
-
             Solidity = FindSolidFaces();
-
             myChangedFaces = Face.All;
         }
 
-        public Octree( int x, int y, int z, int size )
-            : this( size )
-        {
-            X = x;
-            Y = y;
-            Z = z;
-        }
-
-        protected Octree( Octree<T> parent, Octant octant )
-            : this( parent.Size / 2 )
+        protected OctreeNode( OctreeNode<T> parent, Octant octant )
+            : this()
         {
             Parent = parent;
-
-            X = Parent.X + octant.X * Size;
-            Y = Parent.Y + octant.Y * Size;
-            Z = Parent.Z + octant.Z * Size;
-
             myValue = parent.myValue;
         }
 
-        public Octree<T> this[ Octant octant ]
+        public OctreeNode<T> this[ Octant octant ]
         {
             get
             {
@@ -138,29 +182,43 @@ namespace MarsMiner.Shared
             }
         }
 
+        protected Octant FindOctantOfChild( OctreeNode<T> child )
+        {
+            for( int i = 0; i < 8; ++ i )
+                if( child == myChildren[ i ] )
+                    return Octant.All[ i ];
+
+            throw new IndexOutOfRangeException();
+        }
+
+        protected virtual Cuboid FindDimensionsOfChild( OctreeNode<T> child )
+        {
+            Octant oct = FindOctantOfChild( child );
+            Cuboid dims = Parent.FindDimensionsOfChild( this );
+
+            int size = dims.Width >> 1;
+
+            return new Cuboid( dims.X + oct.X * size, dims.Y + oct.Y * size, dims.Z + oct.Z * size, size );
+        }
+
         public void Partition()
         {
             if ( !HasChildren )
             {
-                myChildren = new Octree<T>[]
+                myChildren = new OctreeNode<T>[]
                 {
-                    CreateChild( Octant.All[ 0 ] ),
-                    CreateChild( Octant.All[ 1 ] ),
-                    CreateChild( Octant.All[ 2 ] ),
-                    CreateChild( Octant.All[ 3 ] ),
-                    CreateChild( Octant.All[ 4 ] ),
-                    CreateChild( Octant.All[ 5 ] ),
-                    CreateChild( Octant.All[ 6 ] ),
-                    CreateChild( Octant.All[ 7 ] )
+                    new OctreeNode<T>( this, Octant.All[ 0 ] ),
+                    new OctreeNode<T>( this, Octant.All[ 1 ] ),
+                    new OctreeNode<T>( this, Octant.All[ 2 ] ),
+                    new OctreeNode<T>( this, Octant.All[ 3 ] ),
+                    new OctreeNode<T>( this, Octant.All[ 4 ] ),
+                    new OctreeNode<T>( this, Octant.All[ 5 ] ),
+                    new OctreeNode<T>( this, Octant.All[ 6 ] ),
+                    new OctreeNode<T>( this, Octant.All[ 7 ] )
                 };
 
                 myValue = default( T );
             }
-        }
-
-        protected virtual Octree<T> CreateChild( Octant octant )
-        {
-            return new Octree<T>( this, octant );
         }
 
         public void Merge( T value )
@@ -180,7 +238,7 @@ namespace MarsMiner.Shared
                 Solidity = FindSolidFaces();
                 diff ^= Solidity;
 
-                Octree<T> n;
+                OctreeNode<T> n;
 
                 for ( int i = 1; i < 64; i <<= 1 )
                 {
@@ -250,7 +308,7 @@ namespace MarsMiner.Shared
                 Face face = (Face) i;
                 if ( ( myChangedFaces & face ) != 0 )
                 {
-                    Octree<T> n = FindNeighbour( face );
+                    OctreeNode<T> n = FindNeighbour( face );
                     bool exposed = ( n == null )
                         || ( n.Solidity & Tools.Opposite( face ) ) == 0;
 
@@ -267,97 +325,100 @@ namespace MarsMiner.Shared
             return Face.All;
         }
 
-        public void SetCuboid( Cuboid cuboid, T value )
+        protected void SetCuboid( int x, int y, int z, int size, Cuboid cuboid, T value )
         {
             if ( !HasChildren && Value.Equals( value ) )
                 return;
 
-            Cuboid cube = Cube;
-            if ( cube.IsIntersecting( cuboid ) )
+            if ( cuboid.IsIntersecting( x, y, z, size ) )
             {
-                Cuboid intersection = cube.FindIntersection( cuboid );
-                if ( intersection.Equals( cube ) )
+                Cuboid i = cuboid.FindIntersection( x, y, z, size );
+                if ( i.X == x && i.Y == y && i.Z == z
+                    && i.Width == i.Height && i.Height == i.Depth && i.Depth == size )
                     Merge( value );
-                else if ( intersection.Volume != 0 )
+                else if ( i.Volume != 0 )
                 {
-                    if( !HasChildren )
+                    if ( !HasChildren )
                         Partition();
 
-                    foreach ( Octree<T> child in myChildren )
-                        child.SetCuboid( intersection, value );
+                    int h = size >> 1;
 
-                    if( HasChildren )
+                    foreach ( Octant oct in Octant.All )
+                        this[ oct ].SetCuboid( x + oct.X * h, y + oct.Y * h, z + oct.Z * h, h, i, value );
+
+                    if ( HasChildren )
                         UpdateSolidity();
                 }
             }
         }
 
-        public void SetCuboid( int x, int y, int z, int width, int height, int depth, T value )
+        public virtual OctreeNode<T> FindNode( int x, int y, int z, int size )
         {
-            SetCuboid( new Cuboid( x, y, z, width, height, depth ), value );
+            return Parent.FindNode( x, y, z, size );
         }
 
-        public Octree<T> FindOctree( int x, int y, int z, int size )
+        protected OctreeNode<T> FindNode( int mX, int mY, int mZ, int mSize, int oX, int oY, int oZ, int oSize )
         {
-            if ( size == Size && x == X && y == Y && z == Z )
+            if ( mSize == oSize && mX == oX && mY == oY && mZ == oZ )
                 return this;
 
-            if ( x < Left || y < Bottom || z < Front || x >= Right || y >= Top || z >= Back )
+            if ( oX < mX || oY < mY || oZ < mZ || oX >= mX + mSize
+                || oY >= mY + mSize || oZ >= mZ + mSize )
             {
-                if ( HasParent )
-                    return Parent.FindOctree( x, y, z, size );
-
-                return FindExternalOctree( x, y, z, size );
+                mX ^= ( mX & mSize );
+                mY ^= ( mY & mSize );
+                mZ ^= ( mZ & mSize );
+                mSize <<= 1;
+                return Parent.FindNode( mX, mY, mZ, mSize, oX, oY, oZ, oSize );
             }
 
             if ( HasChildren )
             {
-                int hs = Size >> 1;
-                int child = ( x >= X + hs ? 4 : 0 ) | ( y >= Y + hs ? 2 : 0 ) | ( z >= Z + hs ? 1 : 0 );
+                int hs = mSize >> 1;
+                int cX = ( oX >= mX + hs ? 1 : 0 );
+                int cY = ( oY >= mY + hs ? 1 : 0 );
+                int cZ = ( oZ >= mZ + hs ? 1 : 0 );
+                int child = cX << 2 | cY << 1 | cZ;
 
-                return myChildren[ child ].FindOctree( x, y, z, size );
+                cX = mX + cX * hs;
+                cY = mY + cY * hs;
+                cZ = mZ + cZ * hs;
+
+                return myChildren[ child ].FindNode( cX, cY, cZ, hs, oX, oY, oZ, oSize );
             }
 
             return this;
         }
 
-        public Octree<T> FindNeighbour( Face face )
+        protected virtual OctreeNode<T> FindNeighbour( Face face )
         {
-            int x = X, y = Y, z = Z, size = Size;
+            Cuboid dims = Parent.FindDimensionsOfChild( this );
 
             switch ( face )
             {
                 case Face.Left:
-                    x -= Size; break;
+                    dims.X -= dims.Width; break;
                 case Face.Right:
-                    x += Size; break;
+                    dims.X += dims.Width; break;
                 case Face.Bottom:
-                    y -= Size; break;
+                    dims.Y -= dims.Width; break;
                 case Face.Top:
-                    y += Size; break;
+                    dims.Y += dims.Width; break;
                 case Face.Front:
-                    z -= Size; break;
+                    dims.Z -= dims.Width; break;
                 case Face.Back:
-                    z += Size; break;
+                    dims.Z += dims.Width; break;
             }
 
-            if ( HasParent )
-                return Parent.FindOctree( x, y, z, size );
-
-            return FindExternalOctree( x, y, z, size );
+            return Parent.FindNode( dims.X, dims.Y, dims.Z, dims.Width );
         }
 
-        protected virtual Octree<T> FindExternalOctree( int x, int y, int z, int size )
-        {
-            return null;
-        }
-
-        public IEnumerator<Octree<T>> GetEnumerator()
+        public IEnumerator<OctreeNode<T>> GetEnumerator()
         {
             return new OctreeEnumerator<T>( this );
         }
 
-        public IEnumerator<Octree<T>> GetEnumerator( Face face )
+        public IEnumerator<OctreeNode<T>> GetEnumerator( Face face )
         {
             return new OctreeEnumerator<T>( this, face );
         }

--- a/MarsMiner.Shared/Octree.cs
+++ b/MarsMiner.Shared/Octree.cs
@@ -42,6 +42,11 @@ namespace MarsMiner.Shared
 	        get { return mySize; }
         }
 
+        public override Cuboid Cube
+        {
+            get { return new Cuboid( X, Y, Z, Size ); }
+        }
+
         public Octree( int x, int y, int z, int size )
         {
             myX = x;
@@ -82,11 +87,6 @@ namespace MarsMiner.Shared
 
             return new Cuboid( X + oct.X * size, Y + oct.Y * size, Z + oct.Z * size, size );
         }
-
-        protected override OctreeNode<T> FindNeighbour( Face face )
-        {
-            return null;
-        }
     }
 
     public class OctreeNode<T> : IEnumerable<OctreeNode<T>>
@@ -117,6 +117,11 @@ namespace MarsMiner.Shared
         public virtual int Size
         {
             get { return Parent.Size >> 1; }
+        }
+
+        public virtual Cuboid Cube
+        {
+            get { return Parent.FindDimensionsOfChild( this ); }
         }
 
         public Face Solidity { get; private set; }
@@ -393,7 +398,7 @@ namespace MarsMiner.Shared
 
         protected virtual OctreeNode<T> FindNeighbour( Face face )
         {
-            Cuboid dims = Parent.FindDimensionsOfChild( this );
+            Cuboid dims = Cube;
 
             int size = dims.Width;
 
@@ -413,7 +418,7 @@ namespace MarsMiner.Shared
                     dims.Z += size; break;
             }
 
-            return Parent.FindNode( dims.X, dims.Y, dims.Z, size );
+            return FindNode( dims.X, dims.Y, dims.Z, size );
         }
 
         public IEnumerator<OctreeNode<T>> GetEnumerator()

--- a/MarsMiner.Shared/OctreeEnumerator.cs
+++ b/MarsMiner.Shared/OctreeEnumerator.cs
@@ -5,22 +5,22 @@ using System.Text;
 
 namespace MarsMiner.Shared
 {
-    public class OctreeEnumerator<T> : IEnumerator<Octree<T>>
+    public class OctreeEnumerator<T> : IEnumerator<OctreeNode<T>>
     {
         private OctreeEnumerator<T> myChild;
         private Octant myCurOctant;
         private byte myPassed;
 
-        public readonly Octree<T> Octree;
+        public readonly OctreeNode<T> Octree;
         public readonly Face Face;
 
-        public OctreeEnumerator( Octree<T> octree )
+        public OctreeEnumerator( OctreeNode<T> octree )
             : this( octree, Face.None )
         {
 
         }
 
-        public OctreeEnumerator( Octree<T> octree, Face face )
+        public OctreeEnumerator( OctreeNode<T> octree, Face face )
         {
             Octree = octree;
             Face = face;
@@ -28,7 +28,7 @@ namespace MarsMiner.Shared
             Reset();
         }
 
-        public Octree<T> Current
+        public OctreeNode<T> Current
         {
             get
             {

--- a/MarsMiner.Shared/OctreeTest.cs
+++ b/MarsMiner.Shared/OctreeTest.cs
@@ -15,30 +15,6 @@ namespace MarsMiner.Shared
 
         }
 
-        public void UpdateNeighbours()
-        {
-            for ( int i = 1; i < 16; i <<= 1 )
-            {
-                Face face = (Face) i;
-                OctreeTest n = (OctreeTest) FindNeighbour( face );
-                if ( n != null )
-                {
-                    Face opp = Tools.Opposite( face );
-                    var enumerator = n.GetEnumerator( Tools.Opposite( opp ) );
-                    while ( enumerator.MoveNext() )
-                        enumerator.Current.UpdateFace( opp );
-                }
-            }
-        }
-
-        protected override Face FindSolidFaces()
-        {
-            if ( Value == OctreeTestBlockType.Empty )
-                return Face.None;
-
-            return Face.All;
-        }
-
         protected override OctreeNode<OctreeTestBlockType> FindExternalNode( int x, int y, int z, int size )
         {
             if( Chunk != null )

--- a/MarsMiner.Shared/OctreeTest.cs
+++ b/MarsMiner.Shared/OctreeTest.cs
@@ -9,20 +9,8 @@ namespace MarsMiner.Shared
     {
         public TestChunk Chunk;
 
-        public OctreeTest( int size )
-            : base( size )
-        {
-
-        }
-
         public OctreeTest( int x, int y, int z, int size )
             : base( x, y, z, size )
-        {
-
-        }
-
-        protected OctreeTest( OctreeTest parent, Octant octant )
-            : base( parent, octant )
         {
 
         }
@@ -43,11 +31,6 @@ namespace MarsMiner.Shared
             }
         }
 
-        protected override Octree<OctreeTestBlockType> CreateChild( Octant octant )
-        {
-            return new OctreeTest( this, octant );
-        }
-
         protected override Face FindSolidFaces()
         {
             if ( Value == OctreeTestBlockType.Empty )
@@ -56,10 +39,10 @@ namespace MarsMiner.Shared
             return Face.All;
         }
 
-        protected override Octree<OctreeTestBlockType> FindExternalOctree( int x, int y, int z, int size )
+        protected override OctreeNode<OctreeTestBlockType> FindExternalNode( int x, int y, int z, int size )
         {
-            if( Chunk != null )
-                return Chunk.FindOctree( x, y, z, size );
+            //if( Chunk != null )
+            //    return Chunk.FindOctree( x, y, z, size );
 
             return null;
         }

--- a/MarsMiner.Shared/OctreeTest.cs
+++ b/MarsMiner.Shared/OctreeTest.cs
@@ -41,8 +41,8 @@ namespace MarsMiner.Shared
 
         protected override OctreeNode<OctreeTestBlockType> FindExternalNode( int x, int y, int z, int size )
         {
-            //if( Chunk != null )
-            //    return Chunk.FindOctree( x, y, z, size );
+            if( Chunk != null )
+                return Chunk.FindOctree( x, y, z, size );
 
             return null;
         }

--- a/MarsMiner.Shared/OctreeTestWorldGenerator.cs
+++ b/MarsMiner.Shared/OctreeTestWorldGenerator.cs
@@ -147,15 +147,16 @@ namespace MarsMiner.Shared
                         {
                             int rz = z + nz * res;
                             int pz = nz >> 1;
-
+                            
                             int height = 256;
-
+                            
                             for ( int ix = nx * sca; ix < ( nx + 1 ) * sca; ++ix )
                                 for ( int iz = nz * sca; iz < ( nz + 1 ) * sca; ++iz )
                                     if ( map[ ix, iz ] < height )
                                         height = map[ ix, iz ];
 
-                            height = height / res * res;
+
+                            //int height = map[ nx * sca, nz * sca ] / res * res;
 
                             cur[ nx, nz ] = height;
 

--- a/MarsMiner.Shared/TestChunk.cs
+++ b/MarsMiner.Shared/TestChunk.cs
@@ -61,12 +61,6 @@ namespace MarsMiner.Shared
             Loaded = true;
         }
 
-        public void UpdateNeighbours()
-        {
-            for ( int i = 0; i < Octrees.Length; ++i )
-                Octrees[ i ].UpdateNeighbours();
-        }
-
         public OctreeNode<OctreeTestBlockType> FindOctree( int x, int y, int z, int size )
         {
             if ( x < X || x >= X + ChunkSize || z < Z || z >= Z + ChunkSize )

--- a/MarsMiner.Shared/TestChunk.cs
+++ b/MarsMiner.Shared/TestChunk.cs
@@ -67,7 +67,7 @@ namespace MarsMiner.Shared
                 Octrees[ i ].UpdateNeighbours();
         }
 
-        public OctreeTest FindOctree( int x, int y, int z, int size )
+        public OctreeNode<OctreeTestBlockType> FindOctree( int x, int y, int z, int size )
         {
             if ( x < X || x >= X + ChunkSize || z < Z || z >= Z + ChunkSize )
                 return World.FindOctree( x, y, z, size );
@@ -75,7 +75,7 @@ namespace MarsMiner.Shared
             if ( y < 0 || y >= ChunkHeight || !Loaded )
                 return null;
 
-            return (OctreeTest) Octrees[ y / ChunkSize ].FindOctree( x, y, z, size );
+            return Octrees[ y / ChunkSize ].FindNode( x, y, z, size );
         }
     }
 }

--- a/MarsMiner.Shared/TestWorld.cs
+++ b/MarsMiner.Shared/TestWorld.cs
@@ -35,14 +35,15 @@ namespace MarsMiner.Shared
             myChunksToLoad = new Queue<TestChunk>();
             Generator = new OctreeTestWorldGenerator( seed );
 
-            /*int limit = 1024 / TestChunk.ChunkSize;
+            int limit = 1024 / TestChunk.ChunkSize;
 
             for ( int x = -limit; x < limit; ++x )
                 for ( int z = -limit; z < limit; ++z )
-                    LoadChunk( x * TestChunk.ChunkSize, z * TestChunk.ChunkSize );*/
+                    LoadChunk( x * TestChunk.ChunkSize, z * TestChunk.ChunkSize );
 
+            /*
             LoadChunk( 0, 0 );
-            /*LoadChunk( TestChunk.ChunkSize, 0 );
+            LoadChunk( TestChunk.ChunkSize, 0 );
             LoadChunk( -TestChunk.ChunkSize, 0 );
             LoadChunk( 0, TestChunk.ChunkSize );
             LoadChunk( 0, -TestChunk.ChunkSize );*/

--- a/MarsMiner.Shared/TestWorld.cs
+++ b/MarsMiner.Shared/TestWorld.cs
@@ -118,7 +118,6 @@ namespace MarsMiner.Shared
                 Monitor.Enter( myLoadedChunks );
                 chunk.Generate();
                 myLoadedChunks.Add( FindChunkID( chunk.X, chunk.Z ), chunk );
-                chunk.UpdateNeighbours();
                 Monitor.Exit( myLoadedChunks );
 
                 if ( ChunkLoaded != null )

--- a/MarsMiner.Shared/TestWorld.cs
+++ b/MarsMiner.Shared/TestWorld.cs
@@ -35,14 +35,14 @@ namespace MarsMiner.Shared
             myChunksToLoad = new Queue<TestChunk>();
             Generator = new OctreeTestWorldGenerator( seed );
 
-            int limit = 1024 / TestChunk.ChunkSize;
+            /*int limit = 1024 / TestChunk.ChunkSize;
 
             for ( int x = -limit; x < limit; ++x )
                 for ( int z = -limit; z < limit; ++z )
-                    LoadChunk( x * TestChunk.ChunkSize, z * TestChunk.ChunkSize );/*/
+                    LoadChunk( x * TestChunk.ChunkSize, z * TestChunk.ChunkSize );*/
 
             LoadChunk( 0, 0 );
-            LoadChunk( TestChunk.ChunkSize, 0 );
+            /*LoadChunk( TestChunk.ChunkSize, 0 );
             LoadChunk( -TestChunk.ChunkSize, 0 );
             LoadChunk( 0, TestChunk.ChunkSize );
             LoadChunk( 0, -TestChunk.ChunkSize );*/
@@ -78,7 +78,7 @@ namespace MarsMiner.Shared
             return null;
         }
 
-        public OctreeTest FindOctree( int x, int y, int z, int size )
+        public OctreeNode<OctreeTestBlockType> FindOctree( int x, int y, int z, int size )
         {
             if ( size > TestChunk.ChunkSize )
                 return null;


### PR DESCRIPTION
Reduces the size in memory of an Octree considerably, and world generation rate seems to have improved too. Because no face visibility data is cached, generating vertex data is a bit slower.
